### PR TITLE
Feature/luna base test

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,7 @@ name: Build
 on:
   pull_request:
   push:
-    branches: [main, develop]
+    branches: [main, develop, feature/luna_base_boostfix]
     tags: ['*']
   workflow_dispatch:
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,7 @@ name: Build
 on:
   pull_request:
   push:
-    branches: [main, develop, feature/luna_base_boostfix]
+    branches: [main, develop]
     tags: ['*']
   workflow_dispatch:
 

--- a/Scripts/install_packages.sh
+++ b/Scripts/install_packages.sh
@@ -92,6 +92,7 @@ elif [[ "$1" = "prod" ]]; then
         libboost-program-options1.74.0 \
         libboost-system1.74.0 \
         libboost-thread1.74.0 \
+        libboost-atomic1.74.0 \
         libeigen3-dev \
         libhdf5-cpp-103 \
         libhdf5-dev \


### PR DESCRIPTION
This is a possible change to include libboost_atomic in the luna_base[prod] image.  It is a workaround for the case where our software links to boost::atomic instead of std::atomic in the [dev] image, which then seems to cause a search for boost::atomic in the [prod] image.  This situation seems to happen depending on availability of each library, and possibly on compiler settings.

One drawback of this approach is that there will be one additional library in our luna_base[prod] image.