### PR TITLE
Add boost::atomic to [prod] build.

### DIFF
--- a/Scripts/install_packages.sh
+++ b/Scripts/install_packages.sh
@@ -97,6 +97,7 @@ elif [[ "$1" = "prod" ]]; then
         libboost-program-options1.74.0 \
         libboost-system1.74.0 \
         libboost-thread1.74.0 \
+        libboost-atomic1.74.0 \
         libeigen3-dev \
         libhdf5-cpp-103 \
         libhdf5-dev \


### PR DESCRIPTION
This change installs one additional boost package to the production image, due to its reference in the headers of another required package (boost::atomic) , as in this post:  https://gitlab.kitware.com/cmake/cmake/-/issues/18619 .  